### PR TITLE
忽略导出指针类型的

### DIFF
--- a/unity/Assets/Puerts/Src/Editor/Generator.cs
+++ b/unity/Assets/Puerts/Src/Editor/Generator.cs
@@ -591,7 +591,7 @@ namespace Puerts.Editor
                 baseType = baseType.BaseType;
             }
             type = GetRawType(type);
-            if (type.IsGenericParameter) return;
+            if (type.IsGenericParameter || type.IsPointer) return;
             refTypes.Add(type);
         }
 


### PR DESCRIPTION
指针类型在函数参数带指针时会被引用，函数可以用filter过滤掉
没找到如果用filter过滤引用类型遂改这里